### PR TITLE
Add option processing to the Pod parser

### DIFF
--- a/lib/Text/Markup/Pod.pm
+++ b/lib/Text/Markup/Pod.pm
@@ -18,7 +18,7 @@ sub parser {
     $p->output_string(\my $html);
     # Want user supplied options to override even these default behaviors, 
     # if necessary
-    my $opt = { @$opts };
+    my $opt = $opts ? { @$opts } : {};
     foreach my $method ( keys %$opt ) {
         my $v = $opt->{$method};
         $p->$method($v);

--- a/t/base.t
+++ b/t/base.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 use utf8;
-use Test::More tests => 23;
+use Test::More tests => 25;
 #use Test::More 'no_plan';
 use File::Spec::Functions qw(catdir);
 use HTML::Entities;
@@ -112,6 +112,25 @@ is $parser->parse(
     format  => 'cool',
     options => ['goodbye'],
 ), 'goodbye', 'Test the "cool" parser with options';
+
+my $pod_dir = catdir (qw(t markups));
+
+like $parser->parse(
+        file => "$pod_dir/pod.txt",
+        format => "pod",
+        options => [
+            html_header => '',
+            ],
+        ), qr|</html>|, 'Test pod option to suppress HTML header';
+
+unlike $parser->parse(
+        file => "$pod_dir/pod.txt",
+        format => "pod",
+        options => [
+            html_header => '',
+            html_footer => '',
+            ],
+        ), qr|</html>|, 'Test pod options to suppress HTML header and footer';
 
 # Test the "none" parser.
 my $output = do {


### PR DESCRIPTION
I wanted to use Text::Markup to handle formatting from several different markup styles including Pod, but I needed to have more control over how Pod::Simple::XHTML treated its input and output which led me toward this implementation.

What do you think?
