### PR TITLE
Fix GH-16 and similar cases

### DIFF
--- a/lib/Text/Markup/Asciidoc.pm
+++ b/lib/Text/Markup/Asciidoc.pm
@@ -77,6 +77,7 @@ sub parser {
     return unless $html =~ /\S/;
     utf8::encode $html;
     return qq{<html>
+<head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 </head>
 <body>

--- a/lib/Text/Markup/Bbcode.pm
+++ b/lib/Text/Markup/Bbcode.pm
@@ -16,6 +16,7 @@ sub parser {
     return unless $html =~ /\S/;
     utf8::encode($html);
     return qq{<html>
+<head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 </head>
 <body>

--- a/lib/Text/Markup/Creole.pm
+++ b/lib/Text/Markup/Creole.pm
@@ -15,6 +15,7 @@ sub parser {
     return unless $html =~ /\S/;
     utf8::encode($html);
     return qq{<html>
+<head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 </head>
 <body>

--- a/lib/Text/Markup/Markdown.pm
+++ b/lib/Text/Markup/Markdown.pm
@@ -16,6 +16,7 @@ sub parser {
     return unless $html =~ /\S/;
     utf8::encode($html);
     return qq{<html>
+<head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 </head>
 <body>

--- a/lib/Text/Markup/Mediawiki.pm
+++ b/lib/Text/Markup/Mediawiki.pm
@@ -15,6 +15,7 @@ sub parser {
     return unless $html =~ /\S/;
     utf8::encode($html);
     return qq{<html>
+<head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 </head>
 <body>

--- a/lib/Text/Markup/Multimarkdown.pm
+++ b/lib/Text/Markup/Multimarkdown.pm
@@ -16,6 +16,7 @@ sub parser {
     return unless $html =~ /\S/;
     utf8::encode($html);
     return qq{<html>
+<head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 </head>
 <body>

--- a/lib/Text/Markup/None.pm
+++ b/lib/Text/Markup/None.pm
@@ -14,6 +14,7 @@ sub parser {
     my $html = encode_entities(<$fh>, '<>&"');
     utf8::encode($html);
     return qq{<html>
+<head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 </head>
 <body>

--- a/lib/Text/Markup/Textile.pm
+++ b/lib/Text/Markup/Textile.pm
@@ -21,6 +21,7 @@ sub parser {
     return unless $html =~ /\S/;
     utf8::encode($html);
     return qq{<html>
+<head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 </head>
 <body>

--- a/lib/Text/Markup/Trac.pm
+++ b/lib/Text/Markup/Trac.pm
@@ -16,6 +16,7 @@ sub parser {
     return unless $html =~ /\S/;
     utf8::encode($html);
     return qq{<html>
+<head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 </head>
 <body>

--- a/t/base.t
+++ b/t/base.t
@@ -142,6 +142,7 @@ my $output = do {
     my $html = encode_entities(<$fh>, '<>&"');
     utf8::encode($html);
     qq{<html>
+<head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 </head>
 <body>

--- a/t/html/asciidoc.html
+++ b/t/html/asciidoc.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 </head>
 <body>

--- a/t/html/bbcode.html
+++ b/t/html/bbcode.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 </head>
 <body>

--- a/t/html/creole.html
+++ b/t/html/creole.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 </head>
 <body>

--- a/t/html/markdown.html
+++ b/t/html/markdown.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 </head>
 <body>

--- a/t/html/mediawiki.html
+++ b/t/html/mediawiki.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 </head>
 <body>

--- a/t/html/multimarkdown.html
+++ b/t/html/multimarkdown.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 </head>
 <body>

--- a/t/html/textile.html
+++ b/t/html/textile.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 </head>
 <body>

--- a/t/html/trac.html
+++ b/t/html/trac.html
@@ -1,4 +1,5 @@
 <html>
+<head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 </head>
 <body>


### PR DESCRIPTION
This adds `<head>` to every Text::Markup::* format module where it is missing as well as to the according expected test results.

Closes GH-16 if accepted.