### PR TITLE
Add `raw` option where possible [#2]

### DIFF
--- a/lib/Text/Markup/Asciidoc.pm
+++ b/lib/Text/Markup/Asciidoc.pm
@@ -76,6 +76,7 @@ sub parser {
     # Make sure we have something.
     return unless $html =~ /\S/;
     utf8::encode $html;
+    return $html if $opts->{raw};
     return qq{<html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
@@ -120,6 +121,7 @@ Text::Markup::Asciidoc - Asciidoc parser for Text::Markup
 
   use Text::Markup;
   my $html = Text::Markup->new->parse(file => 'hello.adoc');
+  my $raw_asciidoc = Text::Markup->new->parse(file => 'hello.adoc', raw => 1 );
 
 =head1 Description
 
@@ -138,6 +140,10 @@ recognizes files with the following extensions as Asciidoc:
 =item F<.adoc>
 
 =back
+
+Normally this parser returns the output of C<asciidoc> wrapped in a minimal
+HTML page skeleton. If you would prefer to just get the exact output returned
+by C<asciidoc>, you can pass in a true value for the C<raw> option.
 
 =head1 Author
 

--- a/lib/Text/Markup/Bbcode.pm
+++ b/lib/Text/Markup/Bbcode.pm
@@ -15,6 +15,7 @@ sub parser {
     my $html = $parse->render(<$fh>);
     return unless $html =~ /\S/;
     utf8::encode($html);
+    return $html if $opts->{raw};
     return qq{<html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
@@ -37,6 +38,7 @@ Text::Markup::Bbcode - BBcode parser for Text::Markup
 =head1 Synopsis
 
   my $html = Text::Markup->new->parse(file => 'file.bbcode');
+  my $raw  = Text::Markup->new->parse(file => 'file.bbcode', raw => 1);
 
 =head1 Description
 
@@ -56,6 +58,10 @@ It recognizes files with the following extensions as Markdown:
 =item F<.bbcode>
 
 =back
+
+Normally this module returns the output wrapped in a minimal HTML document
+skeleton. If you would like the raw output with the raw skeleton, you can pass
+the C<raw> option to C<parse>.
 
 =head1 Author
 

--- a/lib/Text/Markup/Creole.pm
+++ b/lib/Text/Markup/Creole.pm
@@ -14,6 +14,7 @@ sub parser {
     my $html = creole_parse(<$fh>);
     return unless $html =~ /\S/;
     utf8::encode($html);
+    return $html if $opts->{raw};
     return qq{<html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
@@ -36,6 +37,7 @@ Text::Markup::Creole - Creole parser for Text::Markup
 =head1 Synopsis
 
   my $html = Text::Markup->new->parse(file => 'file.creole');
+  my $raw  = Text::Markup->new->parse(file => 'file.creole', raw => 1);
 
 =head1 Description
 
@@ -53,6 +55,10 @@ It recognizes files with the following extensions as Markdown:
 =item F<.creole>
 
 =back
+
+Normally this module returns the output wrapped in a minimal HTML document
+skeleton. If you would like the raw output without the skeleton, you can pass
+the C<raw> option to C<parse>.
 
 =head1 Author
 

--- a/lib/Text/Markup/Markdown.pm
+++ b/lib/Text/Markup/Markdown.pm
@@ -15,6 +15,7 @@ sub parser {
     my $html = $md->markdown(<$fh>);
     return unless $html =~ /\S/;
     utf8::encode($html);
+    return $html if $opts->{raw};
     return qq{<html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
@@ -37,6 +38,7 @@ Text::Markup::Markdown - Markdown parser for Text::Markup
 =head1 Synopsis
 
   my $html = Text::Markup->new->parse(file => 'README.md');
+  my $raw  = Text::Markup->new->parse(file => 'README.md', raw => 1);
 
 =head1 Description
 
@@ -62,6 +64,10 @@ It recognizes files with the following extensions as Markdown:
 =item F<.markdown>
 
 =back
+
+Normally this module returns the output wrapped in a minimal HTML document
+skeleton. If you would like the raw output without the skeleton, you can pass
+the C<raw> option to C<parse>.
 
 =head1 See Also
 

--- a/lib/Text/Markup/Mediawiki.pm
+++ b/lib/Text/Markup/Mediawiki.pm
@@ -14,6 +14,7 @@ sub parser {
     my $html = Text::MediawikiFormat::format(<$fh>, @{ $opts || [] });
     return unless $html =~ /\S/;
     utf8::encode($html);
+    return $html if $opts->{raw};
     return qq{<html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
@@ -36,6 +37,7 @@ Text::Markup::Mediawiki - MediaWiki syntax parser for Text::Markup
 =head1 Synopsis
 
   my $html = Text::Markup->new->parse(file => 'README.mediawiki');
+  my $raw  = Text::Markup->new->parse(file => 'README.mediawiki', raw => 1);
 
 =head1 Description
 
@@ -56,6 +58,10 @@ It recognizes files with the following extensions as MediaWiki:
 =item F<.mwiki>
 
 =item F<.wiki>
+
+Normally this module returns the output wrapped in a minimal HTML document
+skeleton. If you would like the raw output without the skeleton, you can pass
+the C<raw> option to C<parse>.
 
 =back
 

--- a/lib/Text/Markup/Multimarkdown.pm
+++ b/lib/Text/Markup/Multimarkdown.pm
@@ -15,6 +15,7 @@ sub parser {
     my $html = $md->markdown(<$fh>);
     return unless $html =~ /\S/;
     utf8::encode($html);
+    return $html if $opts->{raw};
     return qq{<html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
@@ -37,6 +38,7 @@ Text::Markup::Multimarkdown - MultiMarkdown parser for Text::Markup
 =head1 Synopsis
 
   my $html = Text::Markup->new->parse(file => 'README.md');
+  my $raw  = Text::Markup->new->parse(file => 'README.md', raw => 1);
 
 =head1 Description
 
@@ -62,6 +64,10 @@ It recognizes files with the following extensions as MultiMarkdown:
 =item F<.multimarkdown>
 
 =back
+
+Normally this module returns the output wrapped in a minimal HTML document
+skeleton. If you would like the raw output without the skeleton, you can pass
+the C<raw> option to C<parse>.
 
 =head1 Author
 

--- a/lib/Text/Markup/None.pm
+++ b/lib/Text/Markup/None.pm
@@ -13,6 +13,7 @@ sub parser {
     local $/;
     my $html = encode_entities(<$fh>, '<>&"');
     utf8::encode($html);
+    return $html if $opts->{raw};
     return qq{<html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
@@ -35,6 +36,7 @@ Text::Markup::None - Turn a file with no known markup into HTML
 
   use Text::Markup;
   my $html = Text::Markup->new->parse(file => 'README');
+  my $raw  = Text::Markup->new->parse(file => 'README', raw => 1);
 
 =head1 Description
 
@@ -44,6 +46,10 @@ on a L<BOM|http://www.unicode.org/unicode/faq/utf_bom.html#BOM>, encodes all
 entities, and then returns an HTML string with the file in a C<< <pre> >>
 element. This will be handy for files that really are nothing but plain text,
 like F<README> files.
+
+Normally this module returns the output wrapped in a minimal HTML document
+skeleton. If you would like the raw output without the skeleton, you can pass
+the C<raw> option to C<parse>.
 
 =head1 Author
 

--- a/lib/Text/Markup/Textile.pm
+++ b/lib/Text/Markup/Textile.pm
@@ -20,6 +20,7 @@ sub parser {
     my $html = $textile->process(<$fh>);
     return unless $html =~ /\S/;
     utf8::encode($html);
+    return $html if $opts->{raw};
     return qq{<html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
@@ -42,6 +43,7 @@ Text::Markup::Textile - Textile parser for Text::Markup
 =head1 Synopsis
 
   my $html = Text::Markup->new->parse(file => 'README.textile');
+  my $raw  = Text::Markup->new->parse(file => 'README.textile', raw => 1);
 
 =head1 Description
 
@@ -59,6 +61,10 @@ It recognizes files with the following extension as Textile:
 =item F<.textile>
 
 =back
+
+Normally this module returns the output wrapped in a minimal HTML document
+skeleton. If you would like the raw output without the skeleton, you can pass
+the C<raw> option to C<parse>.
 
 =head1 Author
 

--- a/lib/Text/Markup/Trac.pm
+++ b/lib/Text/Markup/Trac.pm
@@ -15,6 +15,7 @@ sub parser {
     my $html = $trac->parse(<$fh>);
     return unless $html =~ /\S/;
     utf8::encode($html);
+    return $html if $opts->{raw};
     return qq{<html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
@@ -37,6 +38,7 @@ Text::Markup::Trac - Trac wiki syntax parser for Text::Markup
 =head1 Synopsis
 
   my $html = Text::Markup->new->parse(file => 'README.trac');
+  my $raw  = Text::Markup->new->parse(file => 'README.trac', raw => 1);
 
 =head1 Description
 
@@ -57,6 +59,10 @@ It recognizes files with the following extensions as Trac:
 =item F<.trc>
 
 =back
+
+Normally this module returns the output wrapped in a minimal HTML document
+skeleton. If you would like the raw output without the skeleton, you can pass
+the C<raw> option to C<parse>.
 
 =head1 Author
 


### PR DESCRIPTION
This adds a `raw` option that can be passed to `parse()` that causes the
parser to return the raw output of the underlying layer, without
wrapping in the minimal HTML skeleton.

This is only possible for a subset of the existing parsers; this patch
makes no attempt to remove the HTML wrappers in the cases where that
wrapper is being added by the underlying parser.

Note also that this patch does not add any tests for this new behavior,
because there don't appear to be any cases where input/output
transformations are actually being currently tested.