### PR TITLE
Port to python3

### DIFF
--- a/lib/Text/Markup/Rest.pm
+++ b/lib/Text/Markup/Rest.pm
@@ -13,7 +13,7 @@ our $VERSION = '0.24';
 
 # Find Python (process stolen from App::Info).
 my ($PYTHON, $RST2HTML);
-for my $exe (WIN32 ? 'python.exe' : 'python') {
+for my $exe (WIN32 ? 'python.exe' : 'python3') {
     my @path = (
         File::Spec->path,
         WIN32 ? (map { "C:\\Python$_" } '', 27, 26, 25) : ()

--- a/lib/Text/Markup/Rest.pm
+++ b/lib/Text/Markup/Rest.pm
@@ -13,7 +13,7 @@ our $VERSION = '0.24';
 
 # Find Python (process stolen from App::Info).
 my ($PYTHON, $RST2HTML);
-for my $exe (WIN32 ? 'python.exe' : 'python3') {
+for my $exe (WIN32 ? 'python3.exe' : 'python3') {
     my @path = (
         File::Spec->path,
         WIN32 ? (map { "C:\\Python$_" } '', 27, 26, 25) : ()

--- a/lib/Text/Markup/rst2html_lenient.py
+++ b/lib/Text/Markup/rst2html_lenient.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python3
 """
 Parse a reST file into HTML in a very forgiving way.
 
@@ -37,12 +37,12 @@ class AnyDirective(Directive):
         children = []
 
         if self.name not in self.state.document.settings.dir_notitle:
-            children.append(nodes.strong(self.name, u"%s: " % self.name))
+            children.append(nodes.strong(self.name, "%s: " % self.name))
             # keep the arguments, drop the options
             for a in self.arguments:
                 if a.startswith(':') and a.endswith(':'):
                     break
-                children.append(nodes.emphasis(a, u"%s " % a))
+                children.append(nodes.emphasis(a, "%s " % a))
 
         if self.name in self.state.document.settings.dir_nested:
             if self.content:
@@ -51,7 +51,7 @@ class AnyDirective(Directive):
                                         container)
                 children.extend(container.children)
         else:
-            content = u'\n'.join(self.content)
+            content = '\n'.join(self.content)
             children.append(nodes.literal_block(content, content))
 
         node = any_directive(self.block_text, '', *children, dir_name=self.name)
@@ -122,7 +122,7 @@ def patch_docutils():
     """Change the docutils parser behaviour."""
     # Patch the constructs dispatch table
     for i, (f, p) in enumerate(Body.explicit.constructs):
-        if f is Body.directive.im_func is f:
+        if f is Body.directive is f:
             Body.explicit.constructs[i] = (catchall_directive, p)
             break
     else:
@@ -229,14 +229,15 @@ Hello `role`:norole:
     try:
         try:
             patch_docutils()
-        except Exception, exc:
+        except Exception as exc:
             problems.append("error during library patching")
             raise
 
         try:
             out = publish_string(TEST_SOURCE,
-                writer=writer, settings_spec=LenientSettingsSpecs)
-        except Exception, exc:
+                writer=writer, settings_spec=LenientSettingsSpecs,
+                settings_overrides={'output_encoding': 'unicode'})
+        except Exception as exc:
             problems.append("error while running patched docutils")
             raise
 
@@ -257,23 +258,22 @@ Hello `role`:norole:
     # report problems if any
     if problems:
         rv = 1
-        print >> sys.stderr, "Patching docutils failed!"
+        print("Patching docutils failed!", file=sys.stderr)
         for problem in problems:
-            print >> sys.stderr, "-", problem
+            print("-", problem, file=sys.stderr)
 
     if rv:
-        print >> sys.stderr, "\nVersions:", \
+        print("\nVersions:", \
             'docutils:', docutils.__version__, docutils.__version_details__, \
-            '\nPython:', sys.version
+            '\nPython:', sys.version, file=sys.stderr)
 
     if exc:
         if '--traceback' in sys.argv:
-            print >> sys.stderr
+            print(file=sys.stderr)
             import traceback
             traceback.print_exc()
         else:
-            print >> sys.stderr, \
-                "\nUse --traceback to display the error stack trace."
+            print("\nUse --traceback to display the error stack trace.", file=sys.stderr)
 
     return rv
 

--- a/lib/Text/Markup/rst2html_lenient.py
+++ b/lib/Text/Markup/rst2html_lenient.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Parse a reST file into HTML in a very forgiving way.
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Text-Markup.
We thought you might be interested in it too.

    Description: Port to python3
    Origin: vendor
    Bug-Debian: https://bugs.debian.org/943159
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2019-10-30
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libtext-markup-perl/raw/master/debian/patches/python3.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
