### PR TITLE
fix version requirement to use correct syntax

### DIFF
--- a/lib/Text/Markup/Pod.pm
+++ b/lib/Text/Markup/Pod.pm
@@ -3,7 +3,7 @@ package Text::Markup::Pod;
 use 5.8.1;
 use strict;
 use warnings;
-use Pod::Simple::XHTML '3.15';
+use Pod::Simple::XHTML 3.15;
 
 # Disable the use of HTML::Entities.
 $Pod::Simple::XHTML::HAS_HTML_ENTITIES = 0;

--- a/lib/Text/Markup/Trac.pm
+++ b/lib/Text/Markup/Trac.pm
@@ -4,7 +4,7 @@ use 5.8.1;
 use strict;
 use warnings;
 use File::BOM qw(open_bom);
-use Text::Trac '0.10';
+use Text::Trac 0.10;
 
 our $VERSION = '0.25';
 


### PR DESCRIPTION
Version numbers on a use line need to be unquoted to be handled properly. When they are quoted, they are passed in import instead. Part versions of perl ignored these arguments, but future versions are intending to throw errors for arguments given to an undefined import method.