### PR TITLE
Add imports to customize extension matching

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup Perl
       uses: shogo82148/actions-setup-perl@v1
     - name: Install Release Dependencies

--- a/Build.PL
+++ b/Build.PL
@@ -33,7 +33,8 @@ my $build = $class->new(
     license            => 'perl',
     create_makefile_pl => 'traditional',
     configure_requires => { 'Module::Build' => '0.4209' },
-    build_requires     => {
+    recommmends        => { 'CommonMark' => '0.290000' },
+    test_requires      => {
         'File::Spec::Functions' => 0,
         'Module::Build'         => '0.4209',
         'Test::More'            => '0.96',
@@ -53,9 +54,6 @@ my $build = $class->new(
         'Text::Trac'            => '0.10',
         'Parse::BBCode'         => '0.15',
         'Text::WikiCreole'      => '0.07',
-    },
-    recommmends => {
-        'CommonMark'            => '0.290000',
     },
     meta_merge => {
          "meta-spec" => { version => 2 },

--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Perl extension Text-Markup.
 
 0.32
+    - Added the ability to change the regular expression for a format by
+      passing it in the `use` statement.
 
 0.31  2023-09-10T23:24:43Z
     - Fixed the passing of parameters to `parse()`.

--- a/lib/Text/Markup.pm
+++ b/lib/Text/Markup.pm
@@ -3,6 +3,7 @@ package Text::Markup;
 use 5.8.1;
 use strict;
 use warnings;
+use Text::Markup;
 use Text::Markup::None;
 use Carp;
 
@@ -146,6 +147,15 @@ This distribution includes support for a number of markup formats:
 =item * L<Trac|https://trac.edgewall.org/wiki/WikiFormatting>
 
 =back
+
+Modules under the Text::Markup namespace provide these parsers, and Text::Markup
+automatically loads them on recognizing file name suffixes documented for each
+module. To change the file extensions recognized for a particular parser (except
+for L<Text::Markup::None>), load it directly and pass a regular expression. For
+example, to have the Mediawiki parser recognized files with the suffixes
+C<truck>, C<truc>, C<track>, or C<trac>, load it like so:
+
+  use Text::Markup::Mediawiki qr{tr[au]ck?};
 
 Adding support for more markup languages is straight-forward, and patches
 adding them to this distribution are also welcome. See L</Add a Parser> for
@@ -304,6 +314,11 @@ C<Text::FooBar> module, it might look something like this:
   use Text::FooBar ();
   use File::BOM qw(open_bom)
 
+  sub import {
+      # Replace the regex if passed one.
+      Text::Markup->register( foobar => $_[1] ) if $_[1];
+  }
+
   sub parser {
       my ($file, $encoding, $opts) = @_;
       my $md = Text::FooBar->new(@{ $opts || [] });
@@ -332,9 +347,8 @@ In such a case, read in the file as raw bytes:
       open my $fh, '<:raw', $file or die "Cannot open $file: $!\n";
 
 The returned HTML, however, B<must be encoded in UTF-8>. Please include an
-L<encoding
-declaration|https://en.wikipedia.org/wiki/Character_encodings_in_HTML>, such
-as a content-type C<< <meta> >> element:
+L<encoding declaration|https://en.wikipedia.org/wiki/Character_encodings_in_HTML>,
+such as a content-type C<< <meta> >> element:
 
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
@@ -430,13 +444,15 @@ UI.
 =back
 
 If you don't want to submit your parser, you can still create and use one
-independently. Rather than add its information to the C<%REGEX_FOR> hash in
-this module, you can just load your parser manually, and have it call the
-C<register> method, like so:
+independently. Just omit editing the C<%REGEX_FOR> hash in this module and make
+sure you C<register> the parser manually with a default regular expression
+in the C<import> method, like so:
 
   package My::Markup::FooBar;
   use Text::Markup;
-  Text::Markup->register(foobar => qr{fb|foob(?:ar)?});
+  sub import {
+      Text::Markup->register( foobar => $_[1] || qr{fb|foob(?:ar)?} );
+  }
 
 This will be useful for creating private parsers you might not want to
 contribute, or that you'd want to distribute independently.

--- a/lib/Text/Markup/Asciidoc.pm
+++ b/lib/Text/Markup/Asciidoc.pm
@@ -3,10 +3,16 @@ package Text::Markup::Asciidoc;
 use 5.8.1;
 use strict;
 use warnings;
+use Text::Markup;
 use Text::Markup::Cmd;
 use utf8;
 
 our $VERSION = '0.32';
+
+sub import {
+    # Replace the regex if passed one.
+    Text::Markup->register( asciidoc => $_[1] ) if $_[1];
+}
 
 my $ASCIIDOC = find_cmd([
     (map { (WIN32 ? ("$_.exe", "$_.bat") : ($_)) } qw(asciidoc)),
@@ -86,6 +92,11 @@ Asciidoc:
 =item F<.adoc>
 
 =back
+
+To change it the files it recognizes, load this module directly and pass a
+regular expression matching the desired extension(s), like so:
+
+  use Text::Markup::Asciidoc qr{ski?doc};
 
 Normally this parser returns the output of C<asciidoc> wrapped in a minimal
 HTML page skeleton. If you would prefer to just get the exact output returned

--- a/lib/Text/Markup/Asciidoctor.pm
+++ b/lib/Text/Markup/Asciidoctor.pm
@@ -3,13 +3,16 @@ package Text::Markup::Asciidoctor;
 use 5.8.1;
 use strict;
 use warnings;
+use Text::Markup;
 use Text::Markup::Cmd;
 use utf8;
 
 our $VERSION = '0.32';
 
-# Replace Text::Markup::Asciidoc.
-Text::Markup->register( asciidoc => qr{a(?:sc(?:iidoc)?|doc)?} );
+sub import {
+    # Replace Text::Markup::Asciidoc.
+    Text::Markup->register( asciidoc => $_[1] || qr{a(?:sc(?:iidoc)?|doc)?} );
+}
 
 # Find Asciidoc.
 my $ASCIIDOC = find_cmd([
@@ -97,6 +100,11 @@ Asciidoc:
 =item F<.adoc>
 
 =back
+
+To change it the files it recognizes, load this module directly and pass a
+regular expression matching the desired extension(s), like so:
+
+  use Text::Markup::AsciiDoctor qr{ski?doc};
 
 Normally this parser returns the output of C<asciidoctor> wrapped in a minimal
 HTML page skeleton. If you would prefer to just get the exact output returned

--- a/lib/Text/Markup/Bbcode.pm
+++ b/lib/Text/Markup/Bbcode.pm
@@ -3,10 +3,16 @@ package Text::Markup::Bbcode;
 use 5.8.1;
 use strict;
 use warnings;
+use Text::Markup;
 use File::BOM qw(open_bom);
 use Parse::BBCode;
 
 our $VERSION = '0.32';
+
+sub import {
+    # Replace the regex if passed one.
+    Text::Markup->register( bbcode => $_[1] ) if $_[1];
+}
 
 sub parser {
     my ($file, $encoding, $opts) = @_;
@@ -63,6 +69,11 @@ It recognizes files with the following extensions as Markdown:
 =item F<.bbcode>
 
 =back
+
+To change it the files it recognizes, load this module directly and pass a
+regular expression matching the desired extension(s), like so:
+
+  use Text::Markup::Bbcode qr{beebee};
 
 Normally this module returns the output wrapped in a minimal HTML document
 skeleton. If you would like the raw output with the raw skeleton, you can pass

--- a/lib/Text/Markup/CommonMark.pm
+++ b/lib/Text/Markup/CommonMark.pm
@@ -9,8 +9,10 @@ use File::BOM qw(open_bom);
 
 our $VERSION = '0.32';
 
-# Replace Text::Markup::Markdown.
-Text::Markup->register( markdown => qr{m(?:d(?:own)?|kdn?|arkdown)} );
+sub import {
+    # Replace Text::Markup::Markdown.
+    Text::Markup->register( markdown => $_[1] || qr{m(?:d(?:own)?|kdn?|arkdown)} );
+}
 
 sub parser {
     my ($file, $encoding, $opts) = @_;
@@ -82,6 +84,11 @@ It recognizes files with the following extensions as CommonMark Markdown:
 =item F<.markdown>
 
 =back
+
+To change it the files it recognizes, load this module directly and pass a
+regular expression matching the desired extension(s), like so:
+
+  use Text::Markup::CommonMark qr{markd?};
 
 Normally this module returns the output wrapped in a minimal HTML document
 skeleton. If you would like the raw output without the skeleton, you can pass

--- a/lib/Text/Markup/Creole.pm
+++ b/lib/Text/Markup/Creole.pm
@@ -3,10 +3,16 @@ package Text::Markup::Creole;
 use 5.8.1;
 use strict;
 use warnings;
+use Text::Markup;
 use File::BOM qw(open_bom);
 use Text::WikiCreole;
 
 our $VERSION = '0.32';
+
+sub import {
+    # Replace the regex if passed one.
+    Text::Markup->register( creole => $_[1] ) if $_[1];
+}
 
 sub parser {
     my ($file, $encoding, $opts) = @_;
@@ -59,6 +65,11 @@ It recognizes files with the following extensions as Markdown:
 =item F<.creole>
 
 =back
+
+To change it the files it recognizes, load this module directly and pass a
+regular expression matching the desired extension(s), like so:
+
+  use Text::Markup::Creole qr{cre+ole+};
 
 Normally this module returns the output wrapped in a minimal HTML document
 skeleton. If you would like the raw output without the skeleton, you can pass

--- a/lib/Text/Markup/HTML.pm
+++ b/lib/Text/Markup/HTML.pm
@@ -3,8 +3,14 @@ package Text::Markup::HTML;
 use 5.8.1;
 use strict;
 use warnings;
+use Text::Markup;
 
 our $VERSION = '0.32';
+
+sub import {
+    # Replace the regex if passed one.
+    Text::Markup->register( html => $_[1] ) if $_[1];
+}
 
 sub parser {
     my ($file, $encoding, $opts) = @_;
@@ -46,6 +52,11 @@ with no decoding. It recognizes files with the following extensions as HTML:
 =item F<.xhtm>
 
 =back
+
+To change it the files it recognizes, load this module directly and pass a
+regular expression matching the desired extension(s), like so:
+
+  use Text::Markup::HTML qr{hachetml};
 
 =head1 Author
 

--- a/lib/Text/Markup/Markdown.pm
+++ b/lib/Text/Markup/Markdown.pm
@@ -3,10 +3,16 @@ package Text::Markup::Markdown;
 use 5.8.1;
 use strict;
 use warnings;
+use Text::Markup;
 use File::BOM qw(open_bom);
 use Text::Markdown ();
 
 our $VERSION = '0.32';
+
+sub import {
+    # Replace the regex if passed one.
+    Text::Markup->register( markdown => $_[1] ) if $_[1];
+}
 
 sub parser {
     my ($file, $encoding, $opts) = @_;
@@ -68,6 +74,11 @@ It recognizes files with the following extensions as Markdown:
 =item F<.markdown>
 
 =back
+
+To change it the files it recognizes, load this module directly and pass a
+regular expression matching the desired extension(s), like so:
+
+  use Text::Markup::Markdown qr{markd?};
 
 Normally this module returns the output wrapped in a minimal HTML document
 skeleton. If you would like the raw output without the skeleton, you can pass

--- a/lib/Text/Markup/Mediawiki.pm
+++ b/lib/Text/Markup/Mediawiki.pm
@@ -3,10 +3,16 @@ package Text::Markup::Mediawiki;
 use 5.8.1;
 use strict;
 use warnings;
+use Text::Markup;
 use File::BOM qw(open_bom);
 use Text::MediawikiFormat 1.0;
 
 our $VERSION = '0.32';
+
+sub import {
+    # Replace the regex if passed one.
+    Text::Markup->register( mediawiki => $_[1] ) if $_[1];
+}
 
 sub parser {
     my ($file, $encoding, $opts) = @_;
@@ -65,6 +71,10 @@ It recognizes files with the following extensions as MediaWiki:
 
 =back
 
+To change it the files it recognizes, load this module directly and pass a
+regular expression matching the desired extension(s), like so:
+
+  use Text::Markup::Mediawiki qr{kwiki?};
 
 Text::Markup::Mediawiki supports the two
 L<Text::MediawikiFormat arguments|Text::MediawikiFormat/format>, a hash

--- a/lib/Text/Markup/Multimarkdown.pm
+++ b/lib/Text/Markup/Multimarkdown.pm
@@ -3,10 +3,16 @@ package Text::Markup::Multimarkdown;
 use 5.8.1;
 use strict;
 use warnings;
+use Text::Markup;
 use File::BOM qw(open_bom);
 use Text::MultiMarkdown ();
 
 our $VERSION = '0.32';
+
+sub import {
+    # Replace the regex if passed one.
+    Text::Markup->register( multimarkdown => $_[1] ) if $_[1];
+}
 
 sub parser {
     my ($file, $encoding, $opts) = @_;
@@ -69,6 +75,11 @@ It recognizes files with the following extensions as MultiMarkdown:
 =item F<.multimarkdown>
 
 =back
+
+To change it the files it recognizes, load this module directly and pass a
+regular expression matching the desired extension(s), like so:
+
+  use Text::Markup::Multimarkdown qr{mmm+};
 
 Normally this module returns the output wrapped in a minimal HTML document
 skeleton. If you would like the raw output without the skeleton, you can pass

--- a/lib/Text/Markup/None.pm
+++ b/lib/Text/Markup/None.pm
@@ -3,6 +3,7 @@ package Text::Markup::None;
 use 5.8.1;
 use strict;
 use warnings;
+use Text::Markup;
 use HTML::Entities;
 use File::BOM qw(open_bom);
 

--- a/lib/Text/Markup/Pod.pm
+++ b/lib/Text/Markup/Pod.pm
@@ -3,7 +3,13 @@ package Text::Markup::Pod;
 use 5.8.1;
 use strict;
 use warnings;
+use Text::Markup;
 use Pod::Simple::XHTML 3.15;
+
+sub import {
+    # Replace the regex if passed one.
+    Text::Markup->register( pod => $_[1] ) if $_[1];
+}
 
 # Disable the use of HTML::Entities.
 $Pod::Simple::XHTML::HAS_HTML_ENTITIES = 0;
@@ -59,6 +65,11 @@ extensions as Pod:
 =item F<.pl>
 
 =back
+
+To change it the files it recognizes, load this module directly and pass a
+regular expression matching the desired extension(s), like so:
+
+  use Text::Markup::Pod qr{cgi};
 
 =head1 Options
 

--- a/lib/Text/Markup/Rest.pm
+++ b/lib/Text/Markup/Rest.pm
@@ -3,10 +3,16 @@ package Text::Markup::Rest;
 use 5.8.1;
 use strict;
 use warnings;
+use Text::Markup;
 use Text::Markup::Cmd;
 use File::Basename;
 
 our $VERSION = '0.32';
+
+sub import {
+    # Replace the regex if passed one.
+    Text::Markup->register( rest => $_[1] ) if $_[1];
+}
 
 # Find Python or die.
 my $PYTHON = find_cmd(
@@ -112,6 +118,11 @@ extensions as reST:
 =item F<.rst>
 
 =back
+
+To change it the files it recognizes, load this module directly and pass a
+regular expression matching the desired extension(s), like so:
+
+  use Text::Markup::Rest qr{re?st(?:aurant)};
 
 =head1 Author
 

--- a/lib/Text/Markup/Textile.pm
+++ b/lib/Text/Markup/Textile.pm
@@ -3,10 +3,16 @@ package Text::Markup::Textile;
 use 5.8.1;
 use strict;
 use warnings;
+use Text::Markup;
 use File::BOM qw(open_bom);
 use Text::Textile 2.10;
 
 our $VERSION = '0.32';
+
+sub import {
+    # Replace the regex if passed one.
+    Text::Markup->register( textile => $_[1] ) if $_[1];
+}
 
 sub parser {
     my ($file, $encoding, $opts) = @_;
@@ -66,6 +72,11 @@ It recognizes files with the following extension as Textile:
 =item F<.textile>
 
 =back
+
+To change it the files it recognizes, load this module directly and pass a
+regular expression matching the desired extension(s), like so:
+
+  use Text::Markup::Textile qr{text(?:ile)?};
 
 Normally this module returns the output wrapped in a minimal HTML document
 skeleton. If you would like the raw output without the skeleton, you can pass

--- a/lib/Text/Markup/Trac.pm
+++ b/lib/Text/Markup/Trac.pm
@@ -3,10 +3,16 @@ package Text::Markup::Trac;
 use 5.8.1;
 use strict;
 use warnings;
+use Text::Markup;
 use File::BOM qw(open_bom);
 use Text::Trac 0.10;
 
 our $VERSION = '0.32';
+
+sub import {
+    # Replace the regex if passed one.
+    Text::Markup->register( trac => $_[1] ) if $_[1];
+}
 
 sub parser {
     my ($file, $encoding, $opts) = @_;
@@ -63,6 +69,11 @@ It recognizes files with the following extensions as Trac:
 =item F<.trc>
 
 =back
+
+To change it the files it recognizes, load this module directly and pass a
+regular expression matching the desired extension(s), like so:
+
+  use Text::Markup::Trac qr{tr[au]ck?};
 
 Normally this module returns the output wrapped in a minimal HTML document
 skeleton. If you would like the raw output without the skeleton, you can pass

--- a/t/formats.t
+++ b/t/formats.t
@@ -43,6 +43,8 @@ my %parsed_filter_for = (
 );
 
 my @loaded = Text::Markup->formats;
+my %regex_for = Text::Markup->format_matchers;
+
 while (my $data = <DATA>) {
     next if $data =~ /^#/;
     chomp $data;
@@ -58,7 +60,7 @@ while (my $data = <DATA>) {
             }
         } if $req;
 
-        plan tests => @exts + 5;
+        plan tests => @exts + 7;
         use_ok $module or next;
 
         push @loaded => $format unless grep { $_ eq $format } @loaded;
@@ -93,6 +95,14 @@ while (my $data = <DATA>) {
             file   => catfile('t', 'empty.txt'),
             format => $format,
         ), undef, "Parse empty $name file";
+
+        # Try recognizing in plain text.
+        is $parser->guess_format('hello.txt'), undef,
+            'guess_format should not match .txt';
+        $module->import(qr/txt/);
+        is $parser->guess_format('hello.txt'), $format,
+            'Now guess_format should match .txt';
+        $module->import($regex_for{$format});
     }
 }
 


### PR DESCRIPTION
Let users easily customize the regular expression used to match files for a given parser by passing a regular expression to the `use` statement for each (except for None).